### PR TITLE
Make ES5/UglifyJS/legacy browser compatible

### DIFF
--- a/uuid-parse.js
+++ b/uuid-parse.js
@@ -10,8 +10,8 @@ for (var i = 0; i < 256; i++) {
 
 // **`parse()` - Parse a UUID into it's component bytes**
 function parse(s, buf, offset) {
-  const i = (buf && offset) || 0;
-  let ii = 0;
+  var i = (buf && offset) || 0;
+  var ii = 0;
 
   buf = buf || [];
   s.toLowerCase().replace(/[0-9a-f]{2}/g, function(oct) {
@@ -30,8 +30,8 @@ function parse(s, buf, offset) {
 
 // **`unparse()` - Convert UUID byte array (ala parse()) into a string**
 function unparse(buf, offset) {
-  let i = offset || 0;
-  const bth = _byteToHex;
+  var i = offset || 0;
+  var bth = _byteToHex;
   return  bth[buf[i++]] + bth[buf[i++]] +
           bth[buf[i++]] + bth[buf[i++]] + '-' +
           bth[buf[i++]] + bth[buf[i++]] + '-' +
@@ -43,6 +43,6 @@ function unparse(buf, offset) {
 }
 
 module.exports = {
-  parse,
-  unparse
+  parse: parse,
+  unparse: unparse
 };


### PR DESCRIPTION
In https://github.com/zefferus/uuid-parse/issues/3, @xaviergxf asked for this module to be made IE11 compatible. Similarly, I'm trying to use this module (more specifically, [slugid](https://github.com/taskcluster/slugid) in a Webpack environment where we prefer not to run Babel on dependencies, so UglifyJS is not able to run on this.

In #3, @PizzaBrandon noted that
> This module targets node. It is recommended that you use a converter such as webpack before deploying node modules to a browser environment.

However, the stated purpose of this module is to make available functions that were removed from [node-uuid](https://github.com/kelektiv/node-uuid), which itself makes a browser-ready version available, so my thinking is that to act as a true replacement for that removal, `uuid-parse` should work in the same environments. The `node-uuid` contributors seem receptive to this argument: https://github.com/kelektiv/node-uuid/issues/250

An alternative to modifying the code in this way might be to make a Babel-fied distribution version available.